### PR TITLE
Install ruby2.x-dev alongside ruby2.x

### DIFF
--- a/recipes/brightbox.rb
+++ b/recipes/brightbox.rb
@@ -27,4 +27,8 @@ end
 
 package node['alternate_ruby']['brightbox_package']
 
+if node['alternate_ruby']['brightbox_package'] >= 'ruby2'
+  package "#{node['alternate_ruby']['brightbox_package']}-dev"
+end
+
 node.override['alternate_ruby']['gem_bin_dir'] = '/usr/local/bin'

--- a/test/cookbooks/alternate_ruby_test/files/default/minitest/brightbox_ruby_ng_test.rb
+++ b/test/cookbooks/alternate_ruby_test/files/default/minitest/brightbox_ruby_ng_test.rb
@@ -12,5 +12,9 @@ describe "alternate_ruby" do
     it "should have the ruby2.1 package installed" do
       package("ruby2.1").must_be_installed
     end
+
+    it "should have the ruby2.1-dev package installed" do
+      package("ruby2.1-dev").must_be_installed
+    end
   end
 end


### PR DESCRIPTION
Brightbox's Ruby 2.0+ packages now include the Ruby headers in a separate package with the "-dev" suffix. This patch will cause Chef to install the corresponding dev package whenever Ruby 2.0+ is the selected package version.
